### PR TITLE
Make registerSchemeHandlerFactory() static

### DIFF
--- a/CEF.swift/Utils/CEFSchemeUtils.swift
+++ b/CEF.swift/Utils/CEFSchemeUtils.swift
@@ -24,7 +24,7 @@ public struct CEFSchemeUtils {
     /// CefRequestContext::GetGlobalContext()->RegisterSchemeHandlerFactory().
     /// CEF name: `CefRegisterSchemeHandlerFactory`
     @discardableResult
-    public func registerSchemeHandlerFactory(_ factory: CEFSchemeHandlerFactory?,
+    public static func registerSchemeHandlerFactory(_ factory: CEFSchemeHandlerFactory?,
                                              forScheme scheme: String,
                                              domain: String? = nil) -> Bool {
         let cefSchemePtr = CEFStringPtrCreateFromSwiftString(scheme)


### PR DESCRIPTION
Otherwise, this method can't be called. (CEFSchemeUtils init method is internal, thus we can't create CEFSchemeUtils objects)